### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ LABEL org.opencontainers.image.title="NGINX Docker Desktop Extension" \
     com.docker.extension.detailed-description="" \
     com.docker.extension.publisher-url="" \
     com.docker.extension.additional-urls="" \
+    com.docker.extension.categories="utility-tools" \
     com.docker.extension.changelog=""
 
 COPY metadata.json .


### PR DESCRIPTION
The automated publishing process has a minimal set of labels that needs to be present, com.docker.extension.categories is one of those but it's not by default included in the init set.  Adding now to save time later.