### PR TITLE
Standarise container

### DIFF
--- a/ui/src/instances/NginxInstances.tsx
+++ b/ui/src/instances/NginxInstances.tsx
@@ -183,7 +183,7 @@ export function NginxInstance() {
                                                 onClick={nginxInstanceOnClickHandler(inst.id, inst.name)}>
                                                 <Typography variant="h5">{inst.name}</Typography>
                                                 <Typography variant="subtitle2" display="inline">Container ID: </Typography>
-                                                <Typography variant="body1" display="inline">{inst.id.substring(0, 8)}...</Typography>
+                                                <Typography variant="body1" display="inline">{inst.id.substring(0, 12)}</Typography>
                                                 <Box paddingTop={1}>
                                                     <Typography variant="subtitle2" display="inline">Status: </Typography>
                                                     <Typography variant="body1" display="inline">{inst.status.toLowerCase()}</Typography>

--- a/ui/src/instances/NginxInstances.tsx
+++ b/ui/src/instances/NginxInstances.tsx
@@ -222,7 +222,7 @@ export function NginxInstance() {
                                     <Typography variant="h5" display="inline">{nginxInstance.name}</Typography>
                                 </Typography>
                                 <Typography variant={"inherit"} paddingLeft={5} paddingBottom={2}>
-                                    Container ID: {nginxInstance.id.substring(0, 8)}...
+                                    Container ID: {nginxInstance.id.substring(0, 12)}
                                 </Typography>
                                 {renderErrorMessageIfAny()}
                             </Grid>


### PR DESCRIPTION
Possibly personal preference but, I think -

![image](https://user-images.githubusercontent.com/850464/224289881-b1f2f5ef-9fd8-4093-b306-5c61deea1dc4.png)

Looks better than 4dc63781...

With the ... in the current example, we're only 1 character off being consistent with the output from the docker cli.

```
james@Jamess-Mac-Studio ~ % docker ps
CONTAINER ID   IMAGE                                       COMMAND                  CREATED          STATUS          PORTS                   NAMES
4dc637819beb   nginx                                       "/docker-entrypoint.…"   46 seconds ago   Up 45 seconds   80/tcp                  elastic_curran
```

It also means that users can easily capture that container id with a mouse and keyboard combo if necessary.

 
